### PR TITLE
Fix missing OpenTelemetry layer in Lambda function

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -136,6 +136,7 @@ data "aws_bedrock_foundation_model" "anthropic" {
 
 # Create dispatcher Lambda function
 resource "local_file" "dispatcher_lambda_code" {
+  count    = var.use_function_url ? 0 : 1
   content  = <<EOF
 import json
 import boto3

--- a/main.tf
+++ b/main.tf
@@ -160,7 +160,7 @@ resource "aws_lambda_function" "slack_bot_lambda" {
   publish = true
 
   # Use Lambda layer for dependencies if created
-  layers = var.enable_application_signals ? [aws_lambda_layer_version.dependencies.arn, var.opentelemetry_python_layer_arns[data.aws_region.current]] : [aws_lambda_layer_version.dependencies.arn]
+  layers = var.enable_application_signals ? [aws_lambda_layer_version.dependencies.arn, var.opentelemetry_python_layer_arns[data.aws_region.current.name]] : [aws_lambda_layer_version.dependencies.arn]
 
   environment {
     variables = merge(


### PR DESCRIPTION
Ensure the OpenTelemetry layer is correctly referenced in the Lambda function configuration and adjust the dispatcher Lambda function creation based on the function URL setting.