### PR TITLE
Use Slack streaming for Bedrock model interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,11 +250,11 @@ aws logs tail /aws/lambda/your-function-name --follow
 | [aws_secretsmanager_secret_version.slack_signing_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_sqs_queue.slackbot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [aws_ssm_parameter.slack_app_manifest](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [local_file.lambda_code](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.requirements_inline_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.slack_app_manifest](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [terraform_data.init_build_directories](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.lambda_build_init](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.lambda_code](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.lambda_code_trigger](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.lambda_layer_build](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [time_static.slack_bot_token_update](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static) | resource |

--- a/lambda/index.py
+++ b/lambda/index.py
@@ -1,142 +1,160 @@
-import json
-import os
-import boto3
-
-
-from slack_bolt import App, Say, SetStatus
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.utilities.batch import (
+    BatchProcessor,
+    EventType,
+    process_partial_response,
+)
+from aws_lambda_powertools.utilities.data_classes import (
+    LambdaFunctionUrlEvent,
+    APIGatewayProxyEvent,
+)
+from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+from aws_lambda_powertools.utilities.parameters import get_secret
+from listeners import register_listeners
+from slack_bolt import App
 from slack_bolt.adapter.aws_lambda import SlackRequestHandler
+from slack_sdk import WebClient
+import json
+import boto3
+import os
 
-# Initialize AWS clients for Bedrock and Secrets Manager
-bedrock_runtime_client = boto3.client("bedrock-runtime")
-secretsmanager_client = boto3.client("secretsmanager")
+logger = Logger()
+tracer = Tracer()
+processor = BatchProcessor(event_type=EventType.SQS)
+sqs = boto3.client("sqs")
 
-slack_token = json.loads(
-    secretsmanager_client.get_secret_value(SecretId=os.environ.get("token"))[
-        "SecretString"
-    ]
-)["token"]
-slack_signing_secret = json.loads(
-    secretsmanager_client.get_secret_value(SecretId=os.environ.get("secret"))[
-        "SecretString"
-    ]
-)["secret"]
+# Slack app setup
+slack_token = get_secret(os.environ.get("token"), transform="json")["token"]
+slack_signing_secret = get_secret(os.environ.get("secret"), transform="json")["secret"]
 
-# Configuration from template variables
-BEDROCK_MODEL_ID = "${bedrock_model_id}"
-
-# process_before_response must be True when running on FaaS
-# see also https://tools.slack.dev/bolt-python/concepts/lazy-listeners/ for an explainer on how to handle long running processes
 app = App(
-    process_before_response=True, signing_secret=slack_signing_secret, token=slack_token
+    signing_secret=slack_signing_secret,
+    client=WebClient(token=slack_token),
+    process_before_response=True,
 )
 
 
-def respond_to_slack_within_3_seconds(body, ack):
-    text = body.get("text")
-    if text is None or len(text) == 0:
-        ack(":x: Usage: /start-process (description here)")
-    else:
-        ack(f"Accepted! (task: {body['text']})")
+def record_handler(record: SQSRecord, context):
+    """Process individual SQS records containing original Lambda events"""
+    # The SQS message body contains the ORIGINAL Lambda event
+    # that SlackRequestHandler expects
+    original_event = json.loads(record.body)
 
-
-def call_bedrock(question):
-    body = json.dumps(
-        {
-            "anthropic_version": "bedrock-2023-05-31",
-            "max_tokens": 3000,
-            "system": "You are a helpful Slack bot assistant. Respond in a friendly and concise manner.",
-            "messages": [{"role": "user", "content": question}],
-            "temperature": 0.5,
-        }
+    logger.info(
+        "Processing Slack event from SQS",
+        extra={
+            "event_type": original_event.get("requestContext", {})
+            .get("http", {})
+            .get("method")
+            or original_event.get("requestContext", {}).get("httpMethod")
+        },
     )
 
-    model_id = BEDROCK_MODEL_ID
-    accept = "application/json"
-    content_type = "application/json"
+    # Pass the original event directly to SlackRequestHandler
+    register_listeners(app)
+    slack_handler = SlackRequestHandler(app=app)
 
-    # Call the Bedrock AI model
-    response = bedrock_runtime_client.invoke_model(
-        body=body, modelId=model_id, accept=accept, contentType=content_type
+    response = slack_handler.handle(original_event, context)
+    logger.info(
+        "Processed Slack event", extra={"status_code": response.get("statusCode")}
     )
 
-    # Process the response from the Bedrock AI model
-    response_content = response["body"].read().decode("utf-8")
-    response_body = json.loads(response_content)
 
-    return response_body.get("content")[0].get("text")
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+def handler(event, context):
+    """
+    Universal handler supporting:
+    - Lambda Function URL (direct from Slack)
+    - API Gateway v1/v2 (direct from Slack)
+    - SQS Event Source Mapping (async processing)
+    """
 
+    # Path 1: SQS Batch Processing
+    if (
+        "Records" in event
+        and event.get("Records", [{}])[0].get("eventSource") == "aws:sqs"
+    ):
+        logger.info(f"Processing {len(event.get('Records', []))} SQS records")
 
-import time
-
-
-def run_long_process(respond, body):
-    time.sleep(5)  # longer than 3 seconds
-    respond(f"Completed! (task: {body['text']})")
-
-
-app.command("/start-process")(
-    ack=respond_to_slack_within_3_seconds,  # responsible for calling `ack()`
-    lazy=[run_long_process],  # unable to call `ack()` / can have multiple functions
-)
-
-
-def acknowledge_message(body, logger, set_status: SetStatus):
-    """Acknowledge the message event and set typing indicator."""
-    event = body.get("event", {})
-    if "bot_id" in event and event["bot_id"] is not None:
-        return
-    try:
-        set_status("is typing...")
-    except Exception as e:
-        logger.error(f"Error setting status: {e}")
-
-
-def process_message_lazily(body, logger, say: Say):
-    """Process the message, call Bedrock, and send a reply."""
-    event = body.get("event", {})
-    text = event.get("text")
-
-    if "bot_id" in event and event["bot_id"] is not None:
-        return
-
-    if not text:
-        logger.info("No text in message, skipping Bedrock call.")
-        return
-
-    try:
-        print(event)
-        generated_text = call_bedrock(text)
-        logger.info(f"Bedrock response: {generated_text}")
-        say(generated_text)
-    except Exception as e:
-        logger.error(f"Error processing event: {e}")
-        say(
-            "Sorry, there was an error communicating with AWS Bedrock. The good news is that your Slack App works! If you want to get Bedrock working, check that you've "
-            "<https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html|enabled model access> "
-            "and are using the correct <https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html#cross-region-inference-use|inference profile>. "
-            "If both of these are true, there is some other error. Check your lambda logs for more info."
+        # Batch process with partial failure handling
+        return process_partial_response(
+            event=event,
+            record_handler=lambda record: record_handler(record, context),
+            processor=processor,
+            context=context,
         )
 
-
-app.event("message")(ack=acknowledge_message, lazy=[process_message_lazily])
-
-
-def handle_challenge(event):
-    body = json.loads(event["body"])
-
-    return {
-        "statusCode": 200,
-        "headers": {"x-slack-no-retry": "1"},
-        "body": body["challenge"],
-    }
-
-
-def handler(event, context):
-    event_body = json.loads(event.get("body"))
-    response = None
-    if event_body.get("type") == "url_verification":
-        response = handle_challenge(event)
-        return response
+    # Path 2: Direct invocation from Slack (Function URL or API Gateway)
     else:
-        slack_handler = SlackRequestHandler(app=app)
-        return slack_handler.handle(event, context)
+        # Detect event type using Powertools data classes
+        event_type = detect_event_type(event)
+        logger.append_keys(event_type=event_type)
+
+        # Parse with appropriate data class
+        if event_type == "function_url":
+            typed_event = LambdaFunctionUrlEvent(event)
+            body = typed_event.body
+        elif event_type in ["api_gateway_v1", "api_gateway_v2"]:
+            typed_event = APIGatewayProxyEvent(event)
+            body = typed_event.body
+        else:
+            logger.error("Unknown event type", extra={"event": event})
+            return {"statusCode": 400, "body": "Unknown event type"}
+
+        # Handle Slack URL verification challenge (synchronous response required)
+        if body:
+            try:
+                body_json = json.loads(body)
+                if body_json.get("type") == "url_verification":
+                    challenge = body_json.get("challenge")
+                    logger.info("Responding to Slack URL verification challenge")
+                    return {
+                        "statusCode": 200,
+                        "headers": {"x-slack-no-retry": "1"},
+                        "body": challenge,
+                    }
+            except json.JSONDecodeError:
+                pass
+
+        # Send ENTIRE original event to SQS for async processing
+        # This preserves the exact format SlackRequestHandler expects
+        queue_url = os.environ.get("SQS_QUEUE_URL")
+        if queue_url:
+            sqs.send_message(
+                QueueUrl=queue_url,
+                MessageBody=json.dumps(event),  # Send the whole event!
+                MessageGroupId=(
+                    context.aws_request_id if queue_url.endswith(".fifo") else None
+                ),
+            )
+            logger.info("Sent event to SQS for async processing")
+        else:
+            # Fallback: process synchronously (for testing or if SQS disabled)
+            logger.warning("No SQS queue configured, processing synchronously")
+            register_listeners(app)
+            slack_handler = SlackRequestHandler(app=app)
+            return slack_handler.handle(event, context)
+
+        # Respond immediately to Slack (meets 3-second requirement)
+        return {"statusCode": 200, "body": ""}
+
+
+def detect_event_type(event: dict) -> str:
+    """Detect whether event is from Function URL, API Gateway v1, or v2"""
+    if "requestContext" in event:
+        request_context = event["requestContext"]
+
+        # Function URL has requestContext.http.method and requestContext.domainName
+        if "http" in request_context and request_context.get("domainName"):
+            return "function_url"
+
+        # API Gateway v2 has requestContext.http
+        elif "http" in request_context:
+            return "api_gateway_v2"
+
+        # API Gateway v1 has requestContext.httpMethod
+        elif "httpMethod" in request_context or "httpMethod" in event:
+            return "api_gateway_v1"
+
+    return "unknown"

--- a/lambda/listeners/__init__.py
+++ b/lambda/listeners/__init__.py
@@ -1,0 +1,6 @@
+from .assistant import assistant
+
+
+def register_listeners(app):
+    # Using assistant middleware is the recommended way.
+    app.assistant(assistant)

--- a/lambda/listeners/assistant.py
+++ b/lambda/listeners/assistant.py
@@ -117,10 +117,9 @@ def process_message_lazily(
     except Exception as e:
         logger.error(f"Error processing event: {e}")
         say(
-            "Sorry, there was an error communicating with AWS Bedrock. The good news is that your Slack App works! If you want to get Bedrock working, check that you've "
-            "<https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html|enabled model access> "
-            "and are using the correct <https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html#cross-region-inference-use|inference profile>. "
-            "If both of these are true, there is some other error. Check your lambda logs for more info."
+            "Sorry, there was an error communicating with AWS Bedrock. The good news is that your Slack App works! If you want to get Bedrock working, check that you "
+            "are using the correct <https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html#cross-region-inference-use|inference profile>. "
+            "If you are, there is some other error. Check your lambda logs for more info."
         )
 
 

--- a/lambda/listeners/assistant.py
+++ b/lambda/listeners/assistant.py
@@ -4,7 +4,7 @@ from slack_bolt import Assistant, BoltContext, Say, SetSuggestedPrompts, SetStat
 from slack_bolt.context.get_thread_context import GetThreadContext
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
-import sys
+
 import os
 
 from .llm_caller import call_bedrock_stream
@@ -71,7 +71,7 @@ def process_message_lazily(
         set_status("is thinking...")
 
         # Call streaming version with live message updates using Slack's chat_stream API
-        returned_message = call_bedrock_stream(
+        call_bedrock_stream(
             messages_in_thread,
             client=client,
             channel=channel_id,
@@ -106,7 +106,7 @@ def process_message_lazily(
         set_status("is thinking...")
 
         # Use Slack's chat_stream API for streaming responses
-        returned_message = call_bedrock_stream(
+        call_bedrock_stream(
             messages_in_thread,
             client=client,
             channel=channel_id,
@@ -170,9 +170,4 @@ def respond_in_assistant_thread(
     say: Say,
     logger=logger,
 ):
-    try:
-        user_message = payload["text"]
-
-    except Exception as e:
-        logger.exception(f"Failed to handle a user message event: {e}")
-        say(f":warning: Something went wrong! ({e})")
+    pass

--- a/lambda/listeners/assistant.py
+++ b/lambda/listeners/assistant.py
@@ -1,0 +1,178 @@
+from aws_lambda_powertools import Logger
+from typing import List, Dict
+from slack_bolt import Assistant, BoltContext, Say, SetSuggestedPrompts, SetStatus
+from slack_bolt.context.get_thread_context import GetThreadContext
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+import sys
+import os
+
+from .llm_caller import call_bedrock_stream
+
+logger = Logger(
+    service=os.environ.get("AWS_LAMBDA_FUNCTION_NAME", "terraform-aws-slackbot")
+)
+assistant = Assistant()
+
+
+def process_message_lazily(
+    payload: dict,
+    logger: Logger,
+    context: BoltContext,
+    set_status: SetStatus,
+    get_thread_context: GetThreadContext,
+    client: WebClient,
+    say: Say,
+):
+    """Process the message, call Bedrock, and send a reply."""
+
+    user_message = payload["text"]
+    user_id = payload.get("user")
+    channel_id = context.channel_id
+    thread_ts = context.thread_ts
+
+    logger.info(
+        "Processing message",
+        extra={
+            "user_id": user_id,
+            "channel_id": channel_id,
+            "thread_ts": thread_ts,
+            "message_preview": user_message[:50] if user_message else "",
+        },
+    )
+
+    if user_message == "Can you generate a brief summary of the referred channel?":
+        # the logic here requires the additional bot scopes:
+        # channels:join, channels:history, groups:history
+        thread_context = get_thread_context()
+        referred_channel_id = thread_context.get("channel_id")
+        try:
+            channel_history = client.conversations_history(
+                channel=referred_channel_id, limit=50
+            )
+        except SlackApiError as e:
+            if e.response["error"] == "not_in_channel":
+                # If this app's bot user is not in the public channel,
+                # we'll try joining the channel and then calling the same API again
+                client.conversations_join(channel=referred_channel_id)
+                channel_history = client.conversations_history(
+                    channel=referred_channel_id, limit=50
+                )
+            else:
+                raise e
+
+        prompt = f"Can you generate a brief summary of these messages in a Slack channel <#{referred_channel_id}>?\n\n"
+        for message in reversed(channel_history.get("messages")):
+            if message.get("user") is not None:
+                prompt += f"\n<@{message['user']}> says: {message['text']}\n"
+        messages_in_thread = [{"role": "user", "content": prompt}]
+
+        # Send initial "thinking..." message for channel summary
+        set_status("is thinking...")
+
+        # Call streaming version with live message updates using Slack's chat_stream API
+        returned_message = call_bedrock_stream(
+            messages_in_thread,
+            client=client,
+            channel=channel_id,
+            thread_ts=thread_ts,
+            team_id=context.team_id,
+            user_id=user_id,
+        )
+        return
+
+    if not user_message:
+        logger.info("No text in message, skipping Bedrock call.")
+        return
+
+    try:
+        replies = client.conversations_replies(
+            channel=context.channel_id,
+            ts=context.thread_ts,
+            oldest=context.thread_ts,
+            limit=10,
+        )
+        messages_in_thread: List[Dict[str, str]] = []
+        for message in replies["messages"]:
+            role = "user" if message.get("bot_id") is None else "assistant"
+            messages_in_thread.append({"role": role, "content": message["text"]})
+
+        logger.debug(
+            "Thread messages retrieved",
+            extra={"message_count": len(messages_in_thread)},
+        )
+        # Send initial "thinking..." message
+
+        set_status("is thinking...")
+
+        # Use Slack's chat_stream API for streaming responses
+        returned_message = call_bedrock_stream(
+            messages_in_thread,
+            client=client,
+            channel=channel_id,
+            thread_ts=thread_ts,
+            team_id=context.team_id,
+            user_id=user_id,
+        )
+    except Exception as e:
+        logger.error(f"Error processing event: {e}")
+        say(
+            "Sorry, there was an error communicating with AWS Bedrock. The good news is that your Slack App works! If you want to get Bedrock working, check that you've "
+            "<https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html|enabled model access> "
+            "and are using the correct <https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html#cross-region-inference-use|inference profile>. "
+            "If both of these are true, there is some other error. Check your lambda logs for more info."
+        )
+
+
+@assistant.thread_started()
+def start_assistant_thread(
+    say: Say,
+    get_thread_context: GetThreadContext,
+    set_suggested_prompts: SetSuggestedPrompts,
+    context: BoltContext,
+    logger=logger,
+):
+    try:
+        say(":wave: Hi, how can I help you today?")
+
+        prompts: List[Dict[str, str]] = []
+
+        thread_context = get_thread_context()
+        logger.debug(
+            "Thread context retrieved",
+            extra={
+                "has_channel": (
+                    thread_context.channel_id is not None if thread_context else False
+                )
+            },
+        )
+        if thread_context is not None and thread_context.channel_id is not None:
+            summarize_channel = {
+                "title": "Summarize the referred channel",
+                "message": "Can you generate a brief summary of the referred channel?",
+            }
+            prompts.append(summarize_channel)
+
+        set_suggested_prompts(prompts=prompts)
+    except Exception as e:
+        logger.exception(f"Failed to handle an assistant_thread_started event: {e}")
+        say(f":warning: Something went wrong! ({e})")
+
+
+# This listener is invoked when the user sends a reply in the assistant thread
+@assistant.user_message(lazy=[process_message_lazily])
+def respond_in_assistant_thread(
+    payload: dict,
+    context: BoltContext,
+    set_status: SetStatus,
+    get_thread_context: GetThreadContext,
+    client: WebClient,
+    say: Say,
+    logger=logger,
+):
+    try:
+        user_message = payload["text"]
+
+    except Exception as e:
+        logger.exception(f"Failed to handle a user message event: {e}")
+        say(f":warning: Something went wrong! ({e})")

--- a/lambda/listeners/llm_caller.py
+++ b/lambda/listeners/llm_caller.py
@@ -69,7 +69,9 @@ def call_bedrock_stream(
     Returns:
         str: Complete response content formatted for Slack
     """
-    logger.debug("Messages being sent to Bedrock", extra={"messages": messages_in_thread})
+    logger.debug(
+        "Messages being sent to Bedrock", extra={"messages": messages_in_thread}
+    )
 
     # Convert thread messages to Bedrock format
     messages = []
@@ -115,7 +117,14 @@ def call_bedrock_stream(
                     streamer.append(markdown_text=markdown_to_slack(delta_text))
 
                 if "messageStop" in event:
-                    logger.info("Bedrock stream stopped", extra={"stop_reason": event['messageStop']['stopReason']})
+                    logger.info(
+                        "Bedrock stream stopped",
+                        extra={
+                            "stop_reason": event.get("messageStop", {}).get(
+                                "stopReason", "unknown"
+                            )
+                        },
+                    )
 
                 if "metadata" in event:
                     metadata = event["metadata"]
@@ -123,10 +132,12 @@ def call_bedrock_stream(
                         logger.info(
                             "Bedrock token usage",
                             extra={
-                                "input_tokens": metadata['usage']['inputTokens'],
-                                "output_tokens": metadata['usage']['outputTokens'],
-                                "total_tokens": metadata['usage']['totalTokens']
-                            }
+                                "input_tokens": metadata["usage"].get("inputTokens", 0),
+                                "output_tokens": metadata["usage"].get(
+                                    "outputTokens", 0
+                                ),
+                                "total_tokens": metadata["usage"].get("totalTokens", 0),
+                            },
                         )
 
         # Stop the Slack stream

--- a/lambda/listeners/llm_caller.py
+++ b/lambda/listeners/llm_caller.py
@@ -1,0 +1,139 @@
+import os
+import re
+from typing import List, Dict
+import boto3
+from aws_lambda_powertools import Logger
+
+logger = Logger(service="llm_caller")
+bedrock_runtime_client = boto3.client("bedrock-runtime")
+BEDROCK_MODEL_ID = os.environ.get("BEDROCK_MODEL_INFERENCE_PROFILE")
+
+DEFAULT_SYSTEM_CONTENT = """
+You're an assistant in a Slack workspace.
+Users in the workspace will ask you to help them write something or to think deeply about a specific topic.
+You'll respond to those questions in a professional way.
+When you include markdown text, convert them to Slack compatible ones.
+When a prompt has Slack's special syntax like <@USER_ID> or <#CHANNEL_ID>, you must keep them as-is in your response.
+"""
+
+
+def markdown_to_slack(content: str) -> str:
+    # Split the input string into parts based on code blocks and inline code
+    parts = re.split(r"(?s)(```.+?```|`[^`\n]+?`)", content)
+
+    # Apply the bold, italic, and strikethrough formatting to text not within code
+    result = ""
+    for part in parts:
+        if part.startswith("```") or part.startswith("`"):
+            result += part
+        else:
+            for o, n in [
+                (
+                    r"\*\*\*(?!\s)([^\*\n]+?)(?<!\s)\*\*\*",
+                    r"_*\1*_",
+                ),  # ***bold italic*** to *_bold italic_*
+                (
+                    r"(?<![\*_])\*(?!\s)([^\*\n]+?)(?<!\s)\*(?![\*_])",
+                    r"_\1_",
+                ),  # *italic* to _italic_
+                (r"\*\*(?!\s)([^\*\n]+?)(?<!\s)\*\*", r"*\1*"),  # **bold** to *bold*
+                (r"__(?!\s)([^_\n]+?)(?<!\s)__", r"*\1*"),  # __bold__ to *bold*
+                (r"~~(?!\s)([^~\n]+?)(?<!\s)~~", r"~\1~"),  # ~~strike~~ to ~strike~
+            ]:
+                part = re.sub(o, n, part)
+            result += part
+    return result
+
+
+def call_bedrock_stream(
+    messages_in_thread: List[Dict[str, str]],
+    system_content: str = DEFAULT_SYSTEM_CONTENT,
+    client=None,
+    channel=None,
+    thread_ts=None,
+    team_id=None,
+    user_id=None,
+):
+    """
+    Streams messages to a Bedrock model with live Slack message updates using Slack's chat_stream API.
+
+    Args:
+        messages_in_thread: List of message dictionaries with 'role' and 'content' keys
+        system_content: System prompt content
+        client: Slack WebClient instance
+        channel: Slack channel ID
+        thread_ts: Thread timestamp for replies
+        team_id: Team ID for the recipient
+        user_id: User ID for the recipient
+
+    Returns:
+        str: Complete response content formatted for Slack
+    """
+    logger.debug("Messages being sent to Bedrock", extra={"messages": messages_in_thread})
+
+    # Convert thread messages to Bedrock format
+    messages = []
+    for msg in messages_in_thread:
+        formatted_msg = {"role": msg["role"], "content": [{"text": msg["content"]}]}
+        messages.append(formatted_msg)
+
+    # System prompts for streaming API
+    system_prompts = [{"text": system_content}]
+
+    model_id = BEDROCK_MODEL_ID
+
+    # Basic inference configuration
+    inference_config = {"temperature": 0.7, "maxTokens": 8192}
+
+    try:
+        # Start Bedrock streaming
+        response = bedrock_runtime_client.converse_stream(
+            modelId=model_id,
+            messages=messages,
+            system=system_prompts,
+            inferenceConfig=inference_config,
+        )
+
+        # Initialize Slack streaming with chat_stream helper
+        # This must be called BEFORE we start iterating through the Bedrock stream
+        streamer = client.chat_stream(
+            channel=channel,
+            thread_ts=thread_ts,
+            recipient_team_id=team_id,
+            recipient_user_id=user_id,
+        )
+
+        # Stream the response directly to Slack
+        stream = response.get("stream")
+
+        if stream:
+            for event in stream:
+                if "contentBlockDelta" in event:
+                    delta_text = event["contentBlockDelta"]["delta"]["text"]
+                    # Stream to Slack using the new API
+                    # Convert to Slack markdown and append to stream
+                    streamer.append(markdown_text=markdown_to_slack(delta_text))
+
+                if "messageStop" in event:
+                    logger.info("Bedrock stream stopped", extra={"stop_reason": event['messageStop']['stopReason']})
+
+                if "metadata" in event:
+                    metadata = event["metadata"]
+                    if "usage" in metadata:
+                        logger.info(
+                            "Bedrock token usage",
+                            extra={
+                                "input_tokens": metadata['usage']['inputTokens'],
+                                "output_tokens": metadata['usage']['outputTokens'],
+                                "total_tokens": metadata['usage']['totalTokens']
+                            }
+                        )
+
+        # Stop the Slack stream
+        streamer.stop()
+
+        return ""
+
+    except Exception:
+        logger.exception("Error in streaming call")
+        raise

--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,7 +1,6 @@
 boto3==1.41.5
 urllib3==2.5.0
 slack-bolt==1.27.0
-slack-sdk>=3.39.0
+slack-sdk>=3.39.0,<4
 aws-lambda-powertools==3.17.0
-aiohttp
-chardet
+

--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,5 +1,7 @@
-boto3==1.39.4
-urllib3==2.0.7
-slack-bolt>=1.21,<2
-slack-sdk>=3.33.1,<4
-openai>=1.95.1
+boto3==1.41.5
+urllib3==2.5.0
+slack-bolt==1.27.0
+slack-sdk>=3.39.0
+aws-lambda-powertools==3.17.0
+aiohttp
+chardet

--- a/main.tf
+++ b/main.tf
@@ -131,7 +131,27 @@ resource "aws_iam_role_policy" "slack_bot_role_policy" {
         ]
         Effect   = "Allow"
         Resource = ["arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${var.lambda_function_name}*"]
-
+      },
+      {
+        Sid = "AllowOnlySpecificMarketplaceSubscription"
+        Action = [
+          "aws-marketplace:ViewSubscriptions",
+          "aws-marketplace:Subscribe"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+        Condition = {
+          "ForAllValues:StringEquals" = {
+            "aws-marketplace:ProductId" = [
+              "prod-4pmewlybdftbs",
+              "prod-xdkflymybwmvi",
+              "prod-4dlfvry4v5hbi"
+            ]
+          }
+          "StringEquals" = {
+            "aws:CalledViaLast" = "bedrock.amazonaws.com"
+          }
+        }
       }
       ],
       local.create_sqs_resources ? [{


### PR DESCRIPTION
Implement Slack streaming to facilitate live message updates from a Bedrock model using the Slack chat_stream API. Update dependencies and adjust resource configurations to support the new functionality.